### PR TITLE
MWE of PassPlugin for MLIR

### DIFF
--- a/llvm/utils/extract_symbols.py
+++ b/llvm/utils/extract_symbols.py
@@ -336,6 +336,9 @@ def extract_symbols(arg):
     get_symbols, should_keep_symbol, calling_convention_decoration, lib = arg
     symbols = dict()
     for symbol in get_symbols(lib):
+        if "mlir4Pass" in symbol:
+            symbols[symbol] = 1 + symbols.setdefault(symbol,0)
+            continue
         symbol = should_keep_symbol(symbol, calling_convention_decoration)
         if symbol:
             symbols[symbol] = 1 + symbols.setdefault(symbol,0)
@@ -489,7 +492,7 @@ if __name__ == '__main__':
             if match:
                 try:
                     names, _ = parse_itanium_nested_name(match.group(2))
-                    if names and names[-2][1]:
+                    if (names and len(names) > 1 and names[-2][1]):
                         name = ''.join([x for x,_ in names])
                 except TooComplexName:
                     # Manglings that are too complex should already have been
@@ -517,3 +520,17 @@ if __name__ == '__main__':
         template_count = template_function_count[template_function_mapping[k]]
         if v == 1 and template_count < 100:
             print(k, file=outfile)
+
+    extra = """\
+_ZTVN4mlir4PassE
+_ZN4mlir12registerPassERKSt8functionIFSt10unique_ptrINS_4PassESt14default_deleteIS2_EEvEE
+_ZNK4mlir10StringAttr8getValueEv
+_ZN4mlir6detail14TypeIDResolverINS_8ModuleOpEvE2idE
+_ZN4mlir9Operation4dumpEv
+_ZN4mlir8ModuleOp10getSymNameEv
+_ZN4mlir8ModuleOp13getBodyRegionEv
+_ZN4mlir6Region10OpIteratorC1EPS0_b
+_ZN4llvm12ilist_detail18SpecificNodeAccessINS0_12node_optionsIN4mlir9OperationELb1ELb0EvEEE11getValuePtrEPNS_15ilist_node_implIS5_EE
+"""
+    for e in extra.splitlines():
+        print(e, file=outfile)

--- a/mlir/HelloMLIR/CMakeLists.txt
+++ b/mlir/HelloMLIR/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.13.4)
+project(HelloWorldMLIR LANGUAGES CXX C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+
+set(LT_LLVM_INSTALL_DIR "/home/mlevental/dev_projects/llvm-project/install" CACHE PATH "LLVM installation directory")
+
+# Add the location of LLVMConfig.cmake to CMake search paths (so that
+# find_package can locate it)
+set(LLVM_DIR "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
+set(MLIR_DIR "${LT_LLVM_INSTALL_DIR}/lib/cmake/mlir/")
+
+find_package(LLVM REQUIRED CONFIG)
+find_package(MLIR REQUIRED CONFIG)
+
+message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+
+list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+
+include(AddLLVM)
+include(AddMLIR)
+
+add_llvm_pass_plugin(HelloWorldMLIR HelloWorldMLIR.cpp)

--- a/mlir/HelloMLIR/HelloWorldMLIR.cpp
+++ b/mlir/HelloMLIR/HelloWorldMLIR.cpp
@@ -1,0 +1,65 @@
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "llvm/Analysis/CallGraph.h"
+#include <cassert>
+#include <iostream>
+#include <mlir/Pass/PassPlugin.h>
+
+using namespace mlir;
+
+namespace {
+
+struct BbqPass
+    : public PassWrapper<BbqPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(BbqPass)
+
+  StringRef getArgument() const final { return "bbq"; }
+  StringRef getDescription() const final {
+    return "my bbq pass the description";
+  }
+  void runOnOperation() override {
+    auto f = getOperation();
+    std::cerr << "-- dump first op in module\n";
+    f.getBodyRegion().getOps().begin()->dump();
+  }
+};
+
+std::unique_ptr<mlir::Pass> createMyCallGraphPass() {
+  return std::make_unique<BbqPass>();
+}
+
+} // namespace
+
+namespace mlir {
+namespace test {
+
+void registerBbqPass() {
+  std::cerr << "-- registering pass\n";
+  registerPass(createMyCallGraphPass);
+  const auto *previousPass = BbqPass::lookupPassInfo(
+      "test-nvgpu-mmasync-f32-to-tf32-patterns");
+  std::cerr << "-- check previously registered pass: " << previousPass->getPassArgument().str() << "\n";
+  const auto *myPass = BbqPass::lookupPassInfo("bbq");
+  std::cerr << "-- check this pass: " << myPass->getPassArgument().str() << "\n";
+  std::cerr << "-- registered pass\n";
+}
+
+} // namespace test
+} // namespace mlir
+
+mlir::PassPluginLibraryInfo getPluginInfo() {
+  auto callback = [](mlir::PassManager &) {
+    test::registerBbqPass();
+  };
+  PassPluginLibraryInfo info{MLIR_PLUGIN_API_VERSION, "Bbq",
+                             LLVM_VERSION_STRING, callback
+
+  };
+  return info;
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::mlir::PassPluginLibraryInfo
+mlirGetPassPluginInfo() {
+  return getPluginInfo();
+}

--- a/mlir/HelloMLIR/linear.mlir
+++ b/mlir/HelloMLIR/linear.mlir
@@ -1,0 +1,6 @@
+module attributes {torch.debug_module_name = "Linear"} {
+  func.func @forward(%arg0: memref<1x10xf32>) -> index {
+    %c0 = arith.constant 0 : index
+    return %c0 : index
+  }
+}

--- a/mlir/include/mlir/Pass/PassPlugin.h
+++ b/mlir/include/mlir/Pass/PassPlugin.h
@@ -1,0 +1,115 @@
+//===- llvm/Passes/PassPlugin.h - Public Plugin API -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This defines the public entry point for new-PM pass plugins.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_PASSES_PASSPLUGIN_H
+#define MLIR_PASSES_PASSPLUGIN_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/DynamicLibrary.h"
+#include "llvm/Support/Error.h"
+#include <cstdint>
+#include <string>
+
+using namespace llvm;
+
+namespace mlir {
+class PassManager;
+
+/// \macro MLIR_PLUGIN_API_VERSION
+/// Identifies the API version understood by this plugin.
+///
+/// When a plugin is loaded, the driver will check it's supported plugin version
+/// against that of the plugin. A mismatch is an error. The supported version
+/// will be incremented for ABI-breaking changes to the \c PassPluginLibraryInfo
+/// struct, i.e. when callbacks are added, removed, or reordered.
+#define MLIR_PLUGIN_API_VERSION 1
+
+extern "C" {
+/// Information about the plugin required to load its passes
+///
+/// This struct defines the core interface for pass plugins and is supposed to
+/// be filled out by plugin implementors. MLIR-side users of a plugin are
+/// expected to use the \c PassPlugin class below to interface with it.
+struct PassPluginLibraryInfo {
+  /// The API version understood by this plugin, usually \c
+  /// MLIR_PLUGIN_API_VERSION
+  uint32_t APIVersion;
+  /// A meaningful name of the plugin.
+  const char *PluginName;
+  /// The version of the plugin.
+  const char *PluginVersion;
+
+  /// The callback for registering plugin passes with a \c PassBuilder
+  /// instance
+  void (*RegisterPassManagerCallbacks)();
+};
+}
+
+/// A loaded pass plugin.
+///
+/// An instance of this class wraps a loaded pass plugin and gives access to
+/// its interface defined by the \c PassPluginLibraryInfo it exposes.
+class PassPlugin {
+public:
+  /// Attempts to load a pass plugin from a given file.
+  ///
+  /// \returns Returns an error if either the library cannot be found or loaded,
+  /// there is no public entry point, or the plugin implements the wrong API
+  /// version.
+  static Expected<PassPlugin> Load(const std::string &Filename);
+
+  /// Get the filename of the loaded plugin.
+  StringRef getFilename() const { return Filename; }
+
+  /// Get the plugin name
+  StringRef getPluginName() const { return Info.PluginName; }
+
+  /// Get the plugin version
+  StringRef getPluginVersion() const { return Info.PluginVersion; }
+
+  /// Get the plugin API version
+  uint32_t getAPIVersion() const { return Info.APIVersion; }
+
+  /// Invoke the PassBuilder callback registration
+  void registerPassManagerCallbacks() const {
+    Info.RegisterPassManagerCallbacks();
+  }
+
+private:
+  PassPlugin(const std::string &Filename, const sys::DynamicLibrary &Library)
+      : Filename(Filename), Library(Library), Info() {}
+
+  std::string Filename;
+  sys::DynamicLibrary Library;
+  PassPluginLibraryInfo Info;
+};
+}
+
+/// The public entry point for a pass plugin.
+///
+/// When a plugin is loaded by the driver, it will call this entry point to
+/// obtain information about this plugin and about how to register its passes.
+/// This function needs to be implemented by the plugin, see the example below:
+///
+/// ```
+/// extern "C" ::mlir::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+/// mlirGetPassPluginInfo() {
+///   return {
+///     MLIR_PLUGIN_API_VERSION, "MyPlugin", "v0.1", [](PassBuilder &PB) { ... }
+///   };
+/// }
+/// ```
+extern "C" ::mlir::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
+mlirGetPassPluginInfo();
+
+#endif /* MLIR_PASSES_PASSPLUGIN_H */

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -14,6 +14,7 @@
 #define MLIR_TOOLS_MLIROPT_MLIROPTMAIN_H
 
 #include "mlir/Support/LogicalResult.h"
+#include "mlir/Pass/PassPlugin.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <cstdlib>

--- a/mlir/lib/Pass/CMakeLists.txt
+++ b/mlir/lib/Pass/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_library(MLIRPass
   Pass.cpp
   PassCrashRecovery.cpp
   PassManagerOptions.cpp
+  PassPlugin.cpp
   PassRegistry.cpp
   PassStatistics.cpp
   PassTiming.cpp

--- a/mlir/lib/Pass/PassPlugin.cpp
+++ b/mlir/lib/Pass/PassPlugin.cpp
@@ -1,0 +1,54 @@
+//===- lib/Passes/PassPluginLoader.cpp - Load Plugins for New PM Passes ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Pass/PassPlugin.h"
+#include <iostream>
+
+#include <cstdint>
+
+using namespace llvm;
+
+Expected<mlir::PassPlugin> mlir::PassPlugin::Load(const std::string &Filename) {
+  std::string Error;
+  auto Library =
+      sys::DynamicLibrary::getPermanentLibrary(Filename.c_str(), &Error);
+  if (!Library.isValid())
+    return make_error<StringError>(Twine("Could not load library '") +
+                                       Filename + "': " + Error,
+                                   inconvertibleErrorCode());
+
+  PassPlugin P{Filename, Library};
+
+  // mlirGetPassPluginInfo should be resolved to the definition from the plugin
+  // we are currently loading.
+  intptr_t getDetailsFn =
+      (intptr_t)Library.getAddressOfSymbol("mlirGetPassPluginInfo");
+
+  if (!getDetailsFn)
+    // If the symbol isn't found, this is probably a legacy plugin, which is an
+    // error
+    return make_error<StringError>(Twine("Plugin entry point not found in '") +
+                                       Filename + "'. Is this a legacy plugin?",
+                                   inconvertibleErrorCode());
+
+  P.Info = reinterpret_cast<decltype(mlirGetPassPluginInfo) *>(getDetailsFn)();
+
+  if (P.Info.APIVersion != MLIR_PLUGIN_API_VERSION)
+    return make_error<StringError>(
+        Twine("Wrong API version on plugin '") + Filename + "'. Got version " +
+            Twine(P.Info.APIVersion) + ", supported version is " +
+            Twine(MLIR_PLUGIN_API_VERSION) + ".",
+        inconvertibleErrorCode());
+
+  if (!P.Info.RegisterPassManagerCallbacks)
+    return make_error<StringError>(Twine("Empty entry callback in plugin '") +
+                                       Filename + "'.'",
+                                   inconvertibleErrorCode());
+
+  return P;
+}

--- a/mlir/tools/mlir-opt/CMakeLists.txt
+++ b/mlir/tools/mlir-opt/CMakeLists.txt
@@ -71,8 +71,10 @@ add_mlir_tool(mlir-opt
 
   DEPENDS
   ${LIBS}
+  SUPPORT_PLUGINS
   )
-target_link_libraries(mlir-opt PRIVATE ${LIBS})
+target_link_libraries(mlir-opt PUBLIC ${LIBS})
+export_executable_symbols_for_plugins(mlir-opt)
 llvm_update_compile_flags(mlir-opt)
 
 mlir_check_all_link_libraries(mlir-opt)


### PR DESCRIPTION
Build `mlir-opt` and then just as simple as 

```shell
$ cd llvm-project/mlir/HelloMLIR
$ mkdir build && make &&  /mlir-opt -load-pass-plugin $(pwd)/HelloWorldMLIR.so --pass-pipeline=bbq linear.mlir > /dev/null

>>>

-- registering pass
-- check previously registered pass: test-nvgpu-mmasync-f32-to-tf32-patterns
-- check this pass: bbq
-- registered pass
-- dump first op in module
func.func @forward(%arg0: memref<1x10xf32>) -> index {
  %c0 = arith.constant 0 : index
  return %c0 : index
}

```